### PR TITLE
Added Python packaging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,7 @@
 *.pyc
 *.log
+
+# BUILD
+*.egg-info/
+build/
+dist/

--- a/foghorn.py
+++ b/foghorn.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python
+
+'''
+    Launches the Foghorn daemon.
+
+    :copyright: (c) 2016 by Eric Rand and Nik LaBelle
+    :license: MIT, see docs/LICENSING for more details.
+'''
+
+from foghornd import Main
+
+if __name__ == '__main__':
+    foghornd = Main()
+    foghornd.run()

--- a/foghornd/Foghorn.py
+++ b/foghornd/Foghorn.py
@@ -1,11 +1,10 @@
 import logging
-from datetime import datetime,timedelta
+from datetime import datetime
 import dateutil.parser
 
 from twisted.internet import defer
 from twisted.names import dns, error
 
-from FoghornSettings import FoghornSettings
 from GreylistEntry import GreylistEntry
 
 class Foghorn(object):

--- a/foghornd/__init__.py
+++ b/foghornd/__init__.py
@@ -1,0 +1,11 @@
+__all__ = [
+    'Foghorn',
+    'FoghornSettings',
+    'GreylistEntry',
+    'Main'
+]
+
+from foghornd import Main
+from Foghorn import Foghorn
+from FoghornSettings import FoghornSettings
+from GreylistEntry import GreylistEntry

--- a/foghornd/foghornd.py
+++ b/foghornd/foghornd.py
@@ -18,7 +18,7 @@ class FoghornDNSServerFactory(server.DNSServerFactory):
     elif protocol.transport.socket.type == socket.SOCK_DGRAM:
       self.peer_address = IPv4Address('UDP', *address)
     else:
-      logger.warn("Unexpected socket type %r" % protocol.transport.socket.type)
+      self.logger.warn("Unexpected socket type %r" % protocol.transport.socket.type)
 
     # Make peer_address available to resolvers that support that attribute
     for resolver in self.resolver.resolvers:
@@ -58,7 +58,3 @@ class Main(object):
 
     reactor.run()
     self.foghorn.saveState()
-
-if __name__=='__main__':
-  foghornd = Main()
-  foghornd.run()

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python
+
+'''
+    Packing for Foghorn.
+
+    :copyright: (c) 2016 by Eric Rand and Nik LaBelle
+    :license: MIT, see docs/LICENSING for more details.
+'''
+
+try:
+    from setuptools import setup
+except ImportError:
+    from distutils.core import setup
+
+
+# SETTINGS
+# --------
+
+DEPENDENCIES = [
+    'twisted'
+]
+
+SHORT_DESCRIPTION = 'Foghorn is a configurable DNS proxy to allow for black-, white-, and greylisting of DNS resources.'
+
+LONG_DESCRIPTION = '''Foghorn is a configurable DNS proxy to allow for
+black-, white-, and greylisting of DNS resources.
+
+foghorn MUST be positioned within a network with egress filtering enabled
+for DNS - only the local resolver can be allowed to make outbound requests
+for DNS.
+
+Also, squid or some similar proxy should be in place to filter naked
+IP requests, in order to mitigate the possibility of certain workarounds
+that would otherwise be available to attackers.
+
+After baselining, the workstations that you desire to protect should be
+configured to use the foghorn server as their DNS resolver, and any ACLs
+adjusted accordingly.
+'''
+
+CLASSIFIERS = [
+    'Development Status :: 3 - Alpha',
+    'Environment :: Console',
+    'Intended Audience :: Information Technology',
+    'Intended Audience :: System Administrators',
+    'License :: OSI Approved :: MIT License',
+    'Programming Language :: Python',
+    'Topic :: Security',
+    'Topic :: System :: Networking :: Monitoring',
+    'Operating System :: Unix',
+    'Operating System :: POSIX :: Linux',
+    'Operating System :: MacOS :: MacOS X',
+    'Operating System :: Microsoft :: Windows',
+]
+
+# SETUP
+# -----
+
+setup(name='Foghorn',
+      version="0.0.1",
+      description=SHORT_DESCRIPTION,
+      long_description=LONG_DESCRIPTION,
+      author="Eric Rand",
+      author_email="foghorn@hasameli.com",
+      maintainer="Eric Rand",
+      maintainer_email="foghorn@hasameli.com",
+      packages=['foghornd'],
+      package_data={'foghornd': [
+          'greydns/*',
+          'settings.json'
+      ]},
+      scripts=['foghorn.py'],
+      include_package_data=True,
+      install_requires=DEPENDENCIES,
+      setup_requires=DEPENDENCIES,
+      zip_safe=False,
+     )


### PR DESCRIPTION
- Removed unused imports
- Added support for packaging via setuptools
- Changed to use a library format with a launcher script to better support setuptools

Foghorn can now be used in one of two ways:

``` bash
$ foghorn.py
```

OR:

``` python
from foghornd import Main
foghorn = Main()
foghorn.run()
```
