### PR TITLE
IPv6 support

### DIFF
--- a/foghornd/foghorn.py
+++ b/foghornd/foghorn.py
@@ -68,7 +68,7 @@ class Foghorn(object):
         Handle rules regarding what resolves by checking whether
         the record requested is in our lists. Order is important.
         """
-        if query.type == dns.A:
+        if query.type in [dns.A, dns.AAAA]:
             if self.check_whitelist(query):
                 return True
             elif self.check_blacklist(query):

--- a/foghornd/foghorn.py
+++ b/foghornd/foghorn.py
@@ -134,9 +134,14 @@ class Foghorn(object):
     def build_response(self, query):
         """Build sinkholed response when disallowing a response."""
         name = query.name.name
-        answer = dns.RRHeader(name=name,
-                              payload=dns.Record_A(address=b'%s' %
-                                                   (self.settings.sinkhole)))
+
+        if query.type == dns.AAAA:
+            answer = dns.RRHeader(name=name,
+                                  type=dns.AAAA,
+                                  payload=dns.Record_AAAA(address=b'%s' % self.settings.sinkhole6))
+        else:
+            answer = dns.RRHeader(name=name,
+                                  payload=dns.Record_A(address=b'%s' % (self.settings.sinkhole)))
         answers = [answer]
         authority = []
         additional = []

--- a/foghornd/settings.json
+++ b/foghornd/settings.json
@@ -6,5 +6,6 @@
     "grey_ip": "192.168.5.1", 
     "greyout": 24, 
     "refresh": 5, 
-    "sinkhole": "127.0.0.1"
+    "sinkhole": "127.0.0.1", 
+    "sinkhole6": "::1"
 }

--- a/foghornd/settings.py
+++ b/foghornd/settings.py
@@ -93,7 +93,7 @@ class FoghornSettings(object):
         return self.data.get("sinkhole6", "::1")
 
     @sinkhole6.setter
-    def sinkhole(self, value):
+    def sinkhole6(self, value):
         self.data["sinkhole6"] = value
 
     @property

--- a/foghornd/settings.py
+++ b/foghornd/settings.py
@@ -87,6 +87,16 @@ class FoghornSettings(object):
         self.data["sinkhole"] = value
 
     @property
+    def sinkhole6(self):
+        """Sinkhole IP for black/greylisting"""
+
+        return self.data.get("sinkhole6", "::1")
+
+    @sinkhole6.setter
+    def sinkhole(self, value):
+        self.data["sinkhole6"] = value
+
+    @property
     def grey_out(self):
         """Time from firstseen to first allowed"""
 


### PR DESCRIPTION
answers AAAA with AAAA responses using ::1 as the default black hole.  The same white|black|grey listing rules apply.
