### PR TITLE
Add class checking to plugin loader

### DIFF
--- a/foghornd/foghorn.py
+++ b/foghornd/foghorn.py
@@ -22,7 +22,9 @@ class Foghorn(object):
         signal.signal(signal.SIGUSR1, self.toggle_baseline)
         signal.signal(signal.SIGHUP, self.reload)
         self.listhandler_manager = PluginManager("foghornd.plugins.listhandler",
-                                                 "./foghornd/plugins/listhandler/")
+                                                 "./foghornd/plugins/listhandler/",
+                                                 "*.py",
+                                                 "ListHandlerBase")
         self.listhandler = self.listhandler_manager.new(self.settings.loader, self.settings)
         self.listhandler.load_lists()
 

--- a/foghornd/plugin_manager.py
+++ b/foghornd/plugin_manager.py
@@ -12,8 +12,8 @@ class PluginManager(object):
     """This class provides a loader for plugins"""
     modules = {}
 
-    def __init__(self, base, path="./plugins/"):
-        self.load_plugins(base, path)
+    def __init__(self, base, path="./plugins/", pattern="*.py", class_type=None): 
+        self.load_plugins(base, path, pattern, class_type)
 
     def new(self, plugin, *args, **kwargs):
         """Create a new plugin type, passing extra args to constructor"""

--- a/foghornd/plugin_manager.py
+++ b/foghornd/plugin_manager.py
@@ -3,6 +3,7 @@
 import os
 import glob
 import imp
+import inspect
 # import name spaces
 import foghornd.plugins.listhandler
 
@@ -19,7 +20,7 @@ class PluginManager(object):
         if self.modules[plugin]:
             return self.modules[plugin](*args, **kwargs)
 
-    def load_plugins(self, base, path, pattern="*.py"):
+    def load_plugins(self, base, path, pattern="*.py", class_type=None):
         """
         Load all modules from a path and return a dictionary of those
         values with the key being module name and they value being the
@@ -29,7 +30,7 @@ class PluginManager(object):
         modules = {}
         for infile in glob.glob(path):
             basename = os.path.basename(infile)
-            if basename == "__init__":
+            if basename == "__init__.py":
                 continue
             plugin_name = basename[:-3]
             plugin_namespace = "%s.%s" % (base, plugin_name)
@@ -37,5 +38,15 @@ class PluginManager(object):
             caller = getattr(plugin, plugin_name, None)
             if caller is None:
                 raise ImportError("Class not found:", plugin_name, plugin)
+            if class_type:
+                if not inherits_from(caller, class_type):
+                    raise ImportError("Wrong class type:", plugin_name, plugin)
             modules[plugin_name] = caller
-        self.modules = modules
+            self.modules = modules
+
+
+def inherits_from(child, parent_name):
+    if inspect.isclass(child):
+        if parent_name in [c.__name__ for c in inspect.getmro(child)[1:]]:
+            return True
+    return False


### PR DESCRIPTION
The plugin loader now takes an option 4th argument and ensures that all modules loaded have inherited from the expected module.
